### PR TITLE
Fix FxControl update logic

### DIFF
--- a/Test Suite/src/org/flixel/plugin/photonstorm/FlxControl.as
+++ b/Test Suite/src/org/flixel/plugin/photonstorm/FlxControl.as
@@ -156,7 +156,7 @@ package org.flixel.plugin.photonstorm
 		/**
 		 * Runs update on all currently active FlxControlHandlers
 		 */
-		override public function draw():void
+		override public function update():void
 		{
 			for each (var handler:FlxControlHandler in members)
 			{


### PR DESCRIPTION
`org.flixel.system.Input` is updating before `FlxControl` has the opportunity to see the `JUST_DOWN` state of the key. When `FlxControl` runs on `draw()` the key state has already changed to `PRESSED`.
